### PR TITLE
Fix language for github issue comments which are PRs

### DIFF
--- a/notifico/services/hooks/github.py
+++ b/notifico/services/hooks/github.py
@@ -212,13 +212,14 @@ class GithubHook(HookService):
     def _handle_issue_comment(cls, user, request, hook, json):
         fmt_string = (
             u'{RESET}[{BLUE}{name}{RESET}] {ORANGE}{who}{RESET} commented on '
-            'issue {GREEN}#{num}{RESET}: {title} - {PINK}{url}{RESET}'
+            '{issue_type} {GREEN}#{num}{RESET}: {title} - {PINK}{url}{RESET}'
         )
 
         yield fmt_string.format(
             name=json['repository']['name'],
             who=json['sender']['login'],
             action=json['action'],
+            issue_type='pull request' if 'pull_request' in json['issue'] else 'issue',
             num=json['issue']['number'],
             title=json['issue']['title'],
             url=GithubHook.shorten(json['comment']['html_url']),


### PR DESCRIPTION
Updates the github issue_comment hook to say whether it is an issue or pull request being commented on.

Warning: I didn't actually test this at all, there could be problems.
