### PR TITLE
hooks: git.io shortener returns 301 redirect on http

### DIFF
--- a/notifico/services/hooks/github.py
+++ b/notifico/services/hooks/github.py
@@ -735,7 +735,7 @@ class GithubHook(HookService):
         # will return a 201 created on success and return the new url
         # in the Location header.
         try:
-            r = requests.post('http://git.io', data={
+            r = requests.post('https://git.io', data={
                 'url': url
             }, timeout=4.0)
         except requests.exceptions.Timeout:


### PR DESCRIPTION
Without https:

```
╰─$ curl -i http://git.io -F "url=https://github.com/"                                                                                            1 ↵
HTTP/1.1 100 Continue

HTTP/1.1 301 Moved Permanently
Server: Cowboy
Connection: close
Date: Thu, 28 Jan 2016 09:04:28 GMT
Status: 301 Moved Permanently
Content-Type: text/html
Location: https://git.io/
Via: 1.1 vegur
```

With https:

```
╰─$ curl -i https://git.io -F "url=https://github.com/"                                                               
HTTP/1.1 100 Continue

HTTP/1.1 201 Created
Server: Cowboy
Connection: keep-alive
Date: Thu, 28 Jan 2016 09:07:08 GMT
Status: 201 Created
Content-Type: text/html;charset=utf-8
Location: https://git.io/p6oxyA
Content-Length: 19
X-Xss-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Runtime: 0.140420
X-Node: 5c27751b-b2a7-48ad-b27b-3a2b56a24121
X-Revision: 4fdc60de6311e6a3aa31e19bc7b3aad7e85d33a6
Strict-Transport-Security: max-age=31536000; includeSubDomains
Via: 1.1 vegur
```
