### PR TITLE
change link from http:// to //

### DIFF
--- a/notifico/templates/body.html
+++ b/notifico/templates/body.html
@@ -21,7 +21,7 @@
     <meta name="author" content="">
 
     <link href="/css/bootstrap.css?v=3" rel="stylesheet">
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     {% block style %}
     {% endblock style %}
     <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">


### PR DESCRIPTION
firefox (and possibly other browsers) give a security warning, because the link is hardcoded to http