### PR TITLE
Use https link in realname + avoid abreviating bot nick

### DIFF
--- a/notifico/bots/manager.py
+++ b/notifico/bots/manager.py
@@ -92,7 +92,7 @@ class BotManager(object):
             Identity(
                 nickname,
                 user=u"notifico",
-                real=u"Notifico! - http://n.tkte.ch/",
+                real=u"Notifico! - https://n.tkte.ch/",
                 password=network.password
             ),
             network.host,


### PR DESCRIPTION
### Changes proposed

- Use https link in bots real name field (its supported and it preferred these days)
~~Avoid bot nick abbreviation ~~

~~Benefits include identification of bot via nick at a glance. It is also important because e.g.labeling/unlabeling (and other) events are not decoupled from the webhook and can and will spew out an impressive amount of spam on channel.~~

~~[A workaround is to silence these bot events (selectively) via script](https://gist.github.com/un1versal/67bc523a2308a0ff15dbdf9ae645491e) which we share on our channel topic for our (less savvy) users to benefit from. However if any nicks (present of future) come into channel with **not/Not** on name its harder to create a matching pattern due also to the random and this can lead to false matches, non abbreviation makes this more unlikely and easier to handle.~~
