### PR TITLE
Catch all request errors in GithubHook.shorten()

### DIFF
--- a/notifico/services/hooks/github.py
+++ b/notifico/services/hooks/github.py
@@ -848,7 +848,7 @@ class GithubHook(HookService):
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             # Ignore these errors since we can't do anything about them.
             return url
-        except:
+        except Exception:
             # Send the others to Sentry.
             from notifico import sentry
             if sentry.client:

--- a/notifico/services/hooks/github.py
+++ b/notifico/services/hooks/github.py
@@ -845,7 +845,14 @@ class GithubHook(HookService):
             r = requests.post('https://git.io', data={
                 'url': url
             }, timeout=4.0)
-        except (requests.exceptions.SSLError, requests.exceptions.Timeout):
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+            # Ignore these errors since we can't do anything about them.
+            return url
+        except:
+            # Send the others to Sentry.
+            from notifico import sentry
+            if sentry.client:
+                sentry.client.captureException()
             return url
 
         # Something went wrong, usually means we're being throttled.


### PR DESCRIPTION
Continuation of #159.

After this the only remaining uncaught exception that I can see is a `KeyError` if a 201 response doesn't contain a `Location` header.