### PR TITLE
Make IRC nickname, username and realname configurable

### DIFF
--- a/notifico/bots/manager.py
+++ b/notifico/bots/manager.py
@@ -12,7 +12,7 @@ from utopia.plugins.util import LogPlugin
 
 from notifico.bots.util import Network
 from notifico.bots.plugins import NickInUsePlugin, CTCPPlugin
-
+import notifico.config as config
 
 logger = logging.getLogger(__name__)
 
@@ -91,8 +91,8 @@ class BotManager(object):
         bot = self._bot_class(
             Identity(
                 nickname,
-                user=u"notifico",
-                real=u"Notifico! - https://n.tkte.ch/",
+                user=config.IRC_USERNAME,
+                real=config.IRC_REALNAME,
                 password=network.password
             ),
             network.host,
@@ -137,9 +137,16 @@ class BotManager(object):
         :param suffix_length: The maximum length for the randomly generated
                               nickname suffix.
         """
+        
+        # Trying the default nickname
+        primary_nick = config.IRC_NICKNAME
+        if primary_nick not in self._nick_stack:
+            self._nick_stack.append(primary_nick)
+            return primary_nick
+
         # Keep trying until we get a nickname that's not already in use.
         while True:
-            new_nick = 'Not-{random_suffix:x}'.format(
+            new_nick = config.IRC_NICKNAME + '-{random_suffix:x}'.format(
                 # By far the fastest pure-python method for a short hex
                 # identifier.
                 random_suffix=random.randrange(

--- a/notifico/config.py
+++ b/notifico/config.py
@@ -44,6 +44,14 @@ REDIS_PORT = 6379
 REDIS_DB = 0
 
 # ---
+# IRC configuration
+# ---
+# If the nickname is taken a random string will get appended
+IRC_NICKNAME = 'Not'
+IRC_USERNAME = u'notifico'
+IRC_REALNAME = u"Notifico! - https://github.com/notifico"
+
+# ---
 # Service integration configuration.
 # ---
 # Your Github OAuth CLIENT_ID and CLIENT_SECRET tokens, as given


### PR DESCRIPTION
This is especially nice for self hosted instances of Notifico.

One can choose a default nickname, which is the first try for nickname usage without any postfix. If it's taken it will append a random string as always.

Half of the credits are going to @a-teammate.