### PR TITLE
update travis webhook doc url

### DIFF
--- a/notifico/services/hooks/templates/travisci_desc.html
+++ b/notifico/services/hooks/templates/travisci_desc.html
@@ -1,1 +1,1 @@
-A simple service intended for Travis CI's <a href="http://about.travis-ci.org/docs/user/notifications/#Webhook-notification">WebHooks</a>.
+A simple service intended for Travis CI's <a href="https://docs.travis-ci.com/user/notifications/#Configuring-webhook-notifications">WebHooks</a>.


### PR DESCRIPTION
The old link is outdated, this may fix it.